### PR TITLE
Reduced the log level of ndwi.py

### DIFF
--- a/pzsvc-exec.conf
+++ b/pzsvc-exec.conf
@@ -1,5 +1,5 @@
 {
-        "CliCmd":"bfalg-ndwi --outdir . --chunksize 1",
+        "CliCmd":"bfalg-ndwi --outdir . --chunksize 1 --verbose 3",
         "VersionCmd":"bfalg-ndwi --version",
         "PzAddrEnVar":"PZ_ADDR",
         "SvcName":"BF_Algo_NDWI_PY",


### PR DESCRIPTION
At the default  log level, gippy logs the reads of all chunks. That's way too many.